### PR TITLE
Add support for HOOMD 3

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Custom
 IncludeBlocks: Regroup
 IndentWidth: 4
+NamespaceIndentation: None
 PenaltyBreakAssignment: 100
 SpacesBeforeTrailingComments: 2
 Standard: Cpp11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,37 +3,19 @@ cmake_minimum_required(VERSION 3.16..3.24)
 # Set-up project
 project(dlext LANGUAGES C CXX)
 
+# Find HOOMD
 set(PROJECT_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_MODULE_PATH})
-
-if(NOT HOOMD_FOUND)
-    find_package(HOOMD 2.6.0 REQUIRED)
-endif()
-
-if(NOT HOOMD_INSTALL_PREFIX)
-    set(HOOMD_INSTALL_PREFIX ${HOOMD_ROOT})
-endif()
-
-if(NOT HOOMD_LIBRARIES)
-    set(HOOMD_LIBRARIES HOOMD::_hoomd)
-endif()
+include("${PROJECT_MODULE_PATH}/FindHOOMDTools.cmake")
 
 include(GNUInstallDirs)
 include("${PROJECT_MODULE_PATH}/FetchCPM.cmake")
 include("${PROJECT_MODULE_PATH}/FetchDLPack.cmake")
-
-# Plugins must be built as shared libraries
-if(ENABLE_STATIC)
-    message(SEND_ERROR "Plugins cannot be built against a statically compiled hoomd")
-endif()
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${HOOMD_INSTALL_PREFIX} CACHE PATH "" FORCE)
 endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-message(STATUS "Install plugin to: " ${CMAKE_INSTALL_PREFIX})
 
 # Create the main library
 add_library(${PROJECT_NAME} SHARED "")
@@ -45,6 +27,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${HOOMD_LIBRARIES} dlpack::dlpack)
 add_subdirectory(dlext)
 
 # Install
+message(STATUS "Plugin will be installed at: ${CMAKE_INSTALL_PREFIX}")
+
 install(TARGETS ${PROJECT_NAME}
     DESTINATION ${HOOMD_INSTALL_PREFIX}
 )

--- a/cmake/Modules/FindHOOMD.cmake
+++ b/cmake/Modules/FindHOOMD.cmake
@@ -1,118 +1,107 @@
-# CMake script for finding HOOMD and setting up all needed compile options to create and link a plugin library
+# FindHOOMD
+# ---------
+#
+# CMake script for finding HOOMD and setting up all needed compile options
+# to create and link a plugin library
 #
 # Variables taken as input to this module:
-# HOOMD_ROOT :          location to look for HOOMD, if it is not in the python path
+# HOOMD_ROOT  --  Location to look for HOOMD, if it is not in the python path
 #
 # Variables defined by this module:
-# FOUND_HOOMD :         set to true if HOOMD is found
-# HOOMD_LIBRARIES :     a list of all libraries needed to link to to access hoomd (uncached)
-# HOOMD_INCLUDE_DIR :   a list of all include directories that need to be set to include HOOMD
-# HOOMD_LIB :           a cached var locating the hoomd library to link to
+# HOOMD_INCLUDE_DIR  --  Include directories that need to be set to include HOOMD
+# HOOMD_LIB          --  Cached var locating the hoomd library to link to
+# HOOMD_LIBRARIES    --  Libraries needed to link to to access hoomd (uncached)
+# HOOMD_FOUND
 #
-# various ENABLE_ flags translated from hoomd_config.h so this plugin build can match the ABI of the installed hoomd
+# Various ENABLE_ flags are translated from hoomd_config.h
+# so this plugin build can match the ABI of the installed hoomd
 #
-# as a convenience (for the intended purpose of this find script), all include directories and definitions needed
-# to compile with all the various libs (boost, python, winsoc, etc...) are set within this script
+# As a convenience (for the intended purpose of this find script),
+# all include directories and definitions needed to compile with all the various libs
+# (boost, python, winsoc, etc...) are set within this script
 
-set(HOOMD_ROOT "" CACHE FILEPATH "Directory containing a hoomd installation (i.e. _hoomd.so)")
-
-# Let HOOMD_ROOT take precedence, but if unset, try letting Python find a hoomd package in its default paths.
-if(HOOMD_ROOT)
-  set(hoomd_installation_guess ${HOOMD_ROOT})
-else(HOOMD_ROOT)
-  find_package(PythonInterp)
-
-  set(find_hoomd_script "
+function(find_hoomd_with_python)
+    find_package(Python QUIET COMPONENTS Interpreter)
+    set(FIND_HOOMD_SCRIPT "
 from __future__ import print_function;
-import sys, os; sys.stdout = open(os.devnull, 'w')
-import hoomd
-print(os.path.dirname(hoomd.__file__), file=sys.stderr, end='')")
+import os
+try:
+    import hoomd
+    print(os.path.dirname(hoomd.__file__), end='')
+except:
+    print('', end='')"
+    )
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -c "${FIND_HOOMD_SCRIPT}"
+        OUTPUT_VARIABLE HOOMD_ROOT
+    )
+    set(HOOMD_DIR ${HOOMD_ROOT} PARENT_SCOPE)
+endfunction()
 
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "${find_hoomd_script}"
-                  ERROR_VARIABLE hoomd_installation_guess)
-  message(STATUS "Python output: " ${hoomd_installation_guess})
-endif(HOOMD_ROOT)
+if(HOOMD_ROOT)
+    set(HOOMD_DIR ${HOOMD_ROOT})
+elseif(DEFINED ENV{HOOMD_ROOT})
+    set(HOOMD_DIR $ENV{HOOMD_ROOT})
+else()
+    find_hoomd_with_python()
+endif()
 
-message(STATUS "Looking for a HOOMD installation at " ${hoomd_installation_guess})
-find_path(FOUND_HOOMD_ROOT
-        NAMES _hoomd.so __init__.py
-        HINTS ${hoomd_installation_guess}
-        )
-
-if(FOUND_HOOMD_ROOT)
-  set(HOOMD_ROOT ${FOUND_HOOMD_ROOT} CACHE FILEPATH "Directory containing a hoomd installation (i.e. _hoomd.so)" FORCE)
-  message(STATUS "Found hoomd installation at " ${HOOMD_ROOT})
-else(FOUND_HOOMD_ROOT)
-  message(FATAL_ERROR "Could not find hoomd installation, either set HOOMD_ROOT or set PYTHON_EXECUTABLE to a python which can find hoomd")
-endif(FOUND_HOOMD_ROOT)
-
-# search for the hoomd include directory
 find_path(HOOMD_INCLUDE_DIR
-          NAMES HOOMDVersion.h
-          HINTS ${HOOMD_ROOT}/include
-          )
+    NAMES HOOMDVersion.h
+    HINTS ${HOOMD_DIR}/include
+)
+if(HOOMD_INCLUDE_DIR)
+    file(READ "${HOOMD_INCLUDE_DIR}/HOOMDVersion.h" HOOMD_VERSION_HEADER)
+    string(REGEX
+        MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" HOOMD_VERSION ${HOOMD_VERSION_HEADER}
+    )
+endif()
+mark_as_advanced(HOOMD_FOUND HOOMD_DIR HOOMD_INCLUDE_DIR HOOMD_VERSION)
 
-if (HOOMD_INCLUDE_DIR)
-    message(STATUS "Found HOOMD include directory: ${HOOMD_INCLUDE_DIR}")
-    mark_as_advanced(HOOMD_INCLUDE_DIR)
-endif (HOOMD_INCLUDE_DIR)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HOOMD
+    REQUIRED_VARS HOOMD_DIR HOOMD_INCLUDE_DIR HOOMD_VERSION
+)
 
-set(HOOMD_FOUND FALSE)
-if (HOOMD_INCLUDE_DIR AND HOOMD_ROOT)
-    set(HOOMD_FOUND TRUE)
-    mark_as_advanced(HOOMD_ROOT)
-endif (HOOMD_INCLUDE_DIR AND HOOMD_ROOT)
+if(HOOMD_FOUND)
+    include_directories(${HOOMD_INCLUDE_DIR})
+    # Run all of HOOMD's generic lib setup scripts
+    set(CMAKE_MODULE_PATH
+        ${HOOMD_DIR}
+        ${HOOMD_DIR}/CMake/hoomd
+        ${HOOMD_DIR}/CMake/thrust
+        ${CMAKE_MODULE_PATH}
+    )
+    # Grab previously-set hoomd configuration
+    include(hoomd_cache)
+    # Handle user build options
+    include(CMake_build_options)
+    include(CMake_preprocessor_flags)
+    # setup the install directories
+    include(CMake_install_options)
+    # Find the python executable and libraries
+    include(HOOMDPythonSetup)
+    # Find CUDA and set it up
+    include(HOOMDCUDASetup)
+    # Set default CFlags
+    include(HOOMDCFlagsSetup)
+    # Include some os specific options
+    include(HOOMDOSSpecificSetup)
+    # Setup common libraries used by all targets in this project
+    include(HOOMDCommonLibsSetup)
+    # Setup macros
+    include(HOOMDMacros)
+    # Setup MPI support
+    include(HOOMDMPISetup)
 
-if (NOT HOOMD_FOUND)
-    message(SEND_ERROR "HOOMD Not found. Please specify the location of your hoomd installation in HOOMD_ROOT")
-endif (NOT HOOMD_FOUND)
+    set(HOOMD_LIB ${HOOMD_DIR}/_hoomd${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_MD_LIB ${HOOMD_DIR}/md/_md${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_DEM_LIB ${HOOMD_DIR}/dem/_dem${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_HPMC_LIB ${HOOMD_DIR}/hpmc/_hpmc${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_CGCMM_LIB ${HOOMD_DIR}/cgcmm/_cgcmm${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_METAL_LIB ${HOOMD_DIR}/metal/_metal${PYTHON_MODULE_EXTENSION})
+    set(HOOMD_DEPRECATED_LIB ${HOOMD_DIR}/deprecated/_deprecated${PYTHON_MODULE_EXTENSION})
 
-#############################################################
-## Now that we've found hoomd, lets do some setup
-if (HOOMD_FOUND)
-
-include_directories(${HOOMD_INCLUDE_DIR})
-
-# run all of HOOMD's generic lib setup scripts
-set(CMAKE_MODULE_PATH ${HOOMD_ROOT}
-                      ${HOOMD_ROOT}/CMake/hoomd
-                      ${HOOMD_ROOT}/CMake/thrust
-                      ${CMAKE_MODULE_PATH}
-                      )
-
-# grab previously-set hoomd configuration
-include (hoomd_cache)
-
-# Handle user build options
-include (CMake_build_options)
-include (CMake_preprocessor_flags)
-# setup the install directories
-include (CMake_install_options)
-
-# Find the python executable and libraries
-include (HOOMDPythonSetup)
-# Find CUDA and set it up
-include (HOOMDCUDASetup)
-# Set default CFlags
-include (HOOMDCFlagsSetup)
-# include some os specific options
-include (HOOMDOSSpecificSetup)
-# setup common libraries used by all targets in this project
-include (HOOMDCommonLibsSetup)
-# setup macros
-include (HOOMDMacros)
-# setup MPI support
-include (HOOMDMPISetup)
-
-set(HOOMD_LIB ${HOOMD_ROOT}/_hoomd${PYTHON_MODULE_EXTENSION})
-set(HOOMD_MD_LIB ${HOOMD_ROOT}/md/_md${PYTHON_MODULE_EXTENSION})
-set(HOOMD_DEM_LIB ${HOOMD_ROOT}/dem/_dem${PYTHON_MODULE_EXTENSION})
-set(HOOMD_HPMC_LIB ${HOOMD_ROOT}/hpmc/_hpmc${PYTHON_MODULE_EXTENSION})
-set(HOOMD_CGCMM_LIB ${HOOMD_ROOT}/cgcmm/_cgcmm${PYTHON_MODULE_EXTENSION})
-set(HOOMD_METAL_LIB ${HOOMD_ROOT}/metal/_metal${PYTHON_MODULE_EXTENSION})
-set(HOOMD_DEPRECATED_LIB ${HOOMD_ROOT}/deprecated/_deprecated${PYTHON_MODULE_EXTENSION})
-
-set(HOOMD_LIBRARIES ${HOOMD_LIB} ${HOOMD_COMMON_LIBS})
-set(HOOMD_LIBRARIES ${HOOMD_LIB} ${HOOMD_COMMON_LIBS})
-
-endif (HOOMD_FOUND)
+    set(HOOMD_LIBRARIES ${HOOMD_LIB} ${HOOMD_COMMON_LIBS})
+    set(HOOMD_LIBRARIES ${HOOMD_LIB} ${HOOMD_COMMON_LIBS})
+endif(HOOMD_FOUND)

--- a/cmake/Modules/FindHOOMDTools.cmake
+++ b/cmake/Modules/FindHOOMDTools.cmake
@@ -1,0 +1,43 @@
+# Try finding HOOMD first from the current environment
+set(HOOMD_GPU_PLATFORM "CUDA" CACHE STRING "GPU backend: CUDA or HIP.")
+find_package(HOOMD QUIET)
+
+if(HOOMD_FOUND)
+    if(${HOOMD_VERSION} VERSION_GREATER_EQUAL "2.6.0")
+        message(STATUS "Found HOOMD: ${HOOMD_DIR} (version ${HOOMD_VERSION})")
+    else()
+        message(FATAL_ERROR "Minimum supported HOOMD version is v2.6.0 (version ${HOOMD_VERSION})")
+    endif()
+endif()
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_MODULE_PATH})
+
+if(NOT HOOMD_FOUND)
+    find_package(HOOMD 2.6.0 REQUIRED)
+endif()
+
+# Plugins must be built as shared libraries
+if(ENABLE_STATIC)
+    message(SEND_ERROR "Plugins cannot be built against a statically compiled hoomd")
+endif()
+
+if(${HOOMD_VERSION} VERSION_LESS "3.4.0")
+    add_compile_definitions(EXPORT_HALFSTEPHOOK)
+    if(${HOOMD_VERSION} VERSION_LESS "3")
+        add_compile_definitions(HOOMD2)
+    endif()
+endif()
+
+if(ENABLE_HIP AND (HIP_PLATFORM STREQUAL "nvcc"))
+    add_compile_definitions(ENABLE_CUDA)
+endif()
+
+if(NOT HOOMD_INSTALL_PREFIX)
+    set(HOOMD_INSTALL_PREFIX ${HOOMD_DIR})
+else()
+    set(HOOMD_INSTALL_PREFIX "${HOOMD_INSTALL_PREFIX}/${PYTHON_SITE_INSTALL_DIR}")
+endif()
+
+if(NOT HOOMD_LIBRARIES)
+    set(HOOMD_LIBRARIES HOOMD::_hoomd HOOMD::_md)
+endif()

--- a/cmake/Modules/FindHOOMDTools.cmake
+++ b/cmake/Modules/FindHOOMDTools.cmake
@@ -3,10 +3,18 @@ set(HOOMD_GPU_PLATFORM "CUDA" CACHE STRING "GPU backend: CUDA or HIP.")
 find_package(HOOMD QUIET)
 
 if(HOOMD_FOUND)
-    if(${HOOMD_VERSION} VERSION_GREATER_EQUAL "2.6.0")
+    if(
+        ${HOOMD_VERSION} VERSION_GREATER_EQUAL "3.5.0" OR (
+            ${HOOMD_VERSION} VERSION_LESS "3" AND
+            ${HOOMD_VERSION} VERSION_GREATER_EQUAL "2.6.0"
+        )
+    )
         message(STATUS "Found HOOMD: ${HOOMD_DIR} (version ${HOOMD_VERSION})")
     else()
-        message(FATAL_ERROR "Minimum supported HOOMD version is v2.6.0 (version ${HOOMD_VERSION})")
+        message(FATAL_ERROR
+            "Supported HOOMD versions are v2.6.0 to v2.9.7 or >= v3.5.0 "
+            "(version ${HOOMD_VERSION})"
+        )
     endif()
 endif()
 
@@ -21,7 +29,7 @@ if(ENABLE_STATIC)
     message(SEND_ERROR "Plugins cannot be built against a statically compiled hoomd")
 endif()
 
-if(${HOOMD_VERSION} VERSION_LESS "3.4.0")
+if(${HOOMD_VERSION} VERSION_LESS "3.5.0")
     add_compile_definitions(EXPORT_HALFSTEPHOOK)
     if(${HOOMD_VERSION} VERSION_LESS "3")
         add_compile_definitions(HOOMD2)

--- a/dlext/include/DLExt.h
+++ b/dlext/include/DLExt.h
@@ -11,9 +11,14 @@
 #include <type_traits>
 #include <vector>
 
+namespace hoomd
+{
+namespace md
+{
 namespace dlext
 {
 
+using namespace cxx11utils;
 using namespace hoomd;
 
 // { // Aliases
@@ -103,5 +108,7 @@ template <>
 constexpr int64_t stride1<unsigned int>() { return 1; }
 
 }  // namespace dlext
+}  // namespace md
+}  // namespace hoomd
 
 #endif  // HOOMD_DLPACK_EXTENSION_H_

--- a/dlext/src/SystemView.cc
+++ b/dlext/src/SystemView.cc
@@ -3,18 +3,18 @@
 
 #include "SystemView.h"
 
-using namespace dlext;
-using namespace cxx11utils;
+using namespace hoomd::md::dlext;
 
-SystemView::SystemView(SystemDefinitionSPtr sysdef)
-    : _sysdef { sysdef }
-    , _pdata { sysdef->getParticleData() }
+SystemView::SystemView(SPtr<System> system)
+    : _system { system }
+    , _pdata { system->getSystemDefinition()->getParticleData() }
 {
     _exec_conf = _pdata->getExecConf();
 }
 
-ParticleDataSPtr SystemView::particle_data() const { return _pdata; }
-ExecutionConfigurationSPtr SystemView::exec_config() const { return _exec_conf; }
+SPtr<System> SystemView::system() { return _system; }
+SPtr<ParticleData> SystemView::particle_data() const { return _pdata; }
+SPtr<const ExecutionConfiguration> SystemView::exec_config() const { return _exec_conf; }
 bool SystemView::is_gpu_enabled() const { return _exec_conf->isCUDAEnabled(); }
 bool SystemView::in_context_manager() const { return _in_context_manager; }
 unsigned int SystemView::local_particle_number() const { return _pdata->getN(); }

--- a/include/cxx11utils.h
+++ b/include/cxx11utils.h
@@ -20,6 +20,9 @@ namespace cxx11utils
 {
 
 template <typename T>
+using SPtr = std::shared_ptr<T>;
+
+template <typename T>
 inline void maybe_unused(T&&)
 { }
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,9 +2,9 @@ set(pybind11_MODULE_NAME "dlpack_extension")
 
 pybind11_add_module(${pybind11_MODULE_NAME} MODULE "")
 
+target_sources(${pybind11_MODULE_NAME} PRIVATE hoomd_dlext.cc)
 target_compile_features(${pybind11_MODULE_NAME} PRIVATE cxx_std_11)
 target_link_libraries(${pybind11_MODULE_NAME} PRIVATE ${PROJECT_NAME})
-target_sources(${pybind11_MODULE_NAME} PRIVATE hoomd_dlext.cc)
 
 # if we are compiling with MPI support built in, set appropriate
 # compiler/linker flags

--- a/python/PyDLExt.h
+++ b/python/PyDLExt.h
@@ -5,8 +5,16 @@
 #define PY_HOOMD_DLPACK_EXTENSION_H_
 
 #include "SystemView.h"
+#ifdef HOOMD2
 #include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+#else
+#include <pybind11/pybind11.h>
+#endif
 
+namespace hoomd
+{
+namespace md
+{
 namespace dlext
 {
 
@@ -84,5 +92,7 @@ void invalidate(PyTensorBundle& bundle)
 }
 
 }  // namespace dlext
+}  // namespace md
+}  // namespace hoomd
 
 #endif  // PY_HOOMD_DLPACK_EXTENSION_H_

--- a/python/PyHalfStepHook.h
+++ b/python/PyHalfStepHook.h
@@ -5,8 +5,17 @@
 #define PY_HOOMD_HS_HOOK_H_
 
 #include "hoomd/HalfStepHook.h"
+#ifdef HOOMD2
 #include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+#else
+#include <pybind11/pybind11.h>
+#endif
+#include "Sampler.h"
 
+namespace hoomd
+{
+namespace md
+{
 namespace dlext
 {
 
@@ -15,21 +24,23 @@ namespace dlext
 //! References:
 //! - https://pybind11.readthedocs.io/en/stable/advanced/classes.html
 //!
-class PyHalfStepHook : public HalfStepHook {
+class DEFAULT_VISIBILITY PyHalfStepHook : public HalfStepHook {
 public:
     using HalfStepHook::HalfStepHook;
 
-    void setSystemDefinition(SystemDefinitionSPtr sysdef) override
+    void setSystemDefinition(SPtr<SystemDefinition> sysdef) override
     {
         PYBIND11_OVERLOAD_PURE(void, HalfStepHook, setSystemDefinition, sysdef);
     }
 
-    void update(unsigned int timestep) override
+    void update(TimeStep timestep) override
     {
         PYBIND11_OVERLOAD_PURE(void, HalfStepHook, update, timestep);
     }
 };
 
 }  // namespace dlext
+}  // namespace md
+}  // namespace hoomd
 
 #endif  // PY_HOOMD_HS_HOOK_H_


### PR DESCRIPTION
This would require making sure that we get fully initialized `System` instances on the before creating `Sampler` objects, e.g. first running `hoomd.run(0)` in HOOMD v2 or `sim.run(0)` in HOOMD v3.