### PR TITLE
CMake suggestion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@ cmake_minimum_required(VERSION 3.16..3.24)
 # Set-up project
 project(dlext LANGUAGES C CXX)
 
-# Try finding HOOMD first from the current environment
-find_package(HOOMD 2.6.0 QUIET)
-
 set(PROJECT_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_MODULE_PATH})
 


### PR DESCRIPTION
I had issues installing hoomd-dlext on midway3.

It finds my local hoomd installation (home directory) just fine.
But the `find_package(hoomd)` causes issues, since it find the system wide installation hoomd to query that.

And that has requirements, we cannot fulfill `thrust 1.5.0`.

Removing the line from the CMakeList.txt resolved the problem, but I am not sure if I breaking other things now.