### PR TITLE
Move HalfStepHook inheritance to python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM ssages/pysages-base:latest
 WORKDIR /hoomd-dlext/.docker_build
 
+# Install python dependencies
+# hadolint ignore=DL3013
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+# hadolint ignore=DL3059
+RUN python3 -m pip install --no-cache-dir "setuptools-scm==7.1.0"
+
+# Build the plugin
 COPY . ../
 RUN cmake .. && make install
+
+# Test it can be loaded
 RUN python3 -c "import hoomd; import hoomd.dlext"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 FROM ssages/pysages-base:latest
-WORKDIR /hoomd-dlext/.docker_build
+WORKDIR /hoomd-dlext
 
 # Install python dependencies
 # hadolint ignore=DL3013
-RUN python3 -m pip install --no-cache-dir --upgrade pip
-# hadolint ignore=DL3059
-RUN python3 -m pip install --no-cache-dir "setuptools-scm==7.1.0"
+RUN python3 -m pip install --no-cache-dir --upgrade pip "setuptools-scm==7.1.0"
 
 # Build the plugin
-COPY . ../
-RUN cmake .. && make install
+COPY . .
+RUN cmake -S . -B build && cmake --build build --target install && rm -rf build
 
 # Test it can be loaded
 RUN python3 -c "import hoomd; import hoomd.dlext"

--- a/cmake/Modules/FindHOOMDTools.cmake
+++ b/cmake/Modules/FindHOOMDTools.cmake
@@ -1,3 +1,25 @@
+# This requires setuptools-scm to be installed as we will use it to setup the module version
+function(set_version target)
+    find_package(Python QUIET COMPONENTS Interpreter)
+    set(GET_VERSION_SCRIPT "
+from setuptools_scm import get_version
+print(get_version(), end='')"
+    )
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -c ${GET_VERSION_SCRIPT}
+        ERROR_VARIABLE error
+        OUTPUT_VARIABLE GIT_VERSION
+        RESULT_VARIABLE exit_code
+    )
+    if(NOT exit_code EQUAL 0)
+        message(FATAL_ERROR
+            "The build process depends on setuptools-scm, make sure it is installed. "
+            "Got the following error:\n${error}"
+        )
+    endif()
+    target_compile_definitions(${target} PUBLIC GIT_VERSION=${GIT_VERSION})
+endfunction()
+
 # Try finding HOOMD first from the current environment
 set(HOOMD_GPU_PLATFORM "CUDA" CACHE STRING "GPU backend: CUDA or HIP.")
 find_package(HOOMD QUIET)

--- a/dlext/include/CallbackHandler.h
+++ b/dlext/include/CallbackHandler.h
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 // This file is part of `hoomd-dlext`, see LICENSE.md
 
-#ifndef DLEXT_SAMPLER_H_
-#define DLEXT_SAMPLER_H_
+#ifndef DLEXT_CALLBACKHANDLER_H_
+#define DLEXT_CALLBACKHANDLER_H_
 
-#include "SystemView.h"
-#include "hoomd/HalfStepHook.h"
+#include "DLExt.h"
 
 namespace hoomd
 {
@@ -20,27 +19,13 @@ using TimeStep = unsigned int;
 using TimeStep = uint64_t;
 #endif
 
-template <typename ExternalUpdater, template <typename> class Wrapper>
-class DEFAULT_VISIBILITY Sampler : public HalfStepHook {
+template <template <typename> class Wrapper>
+class DEFAULT_VISIBILITY CallbackHandler {
 public:
     //! Constructor
-    Sampler(
-        SystemView& sysview,
-        ExternalUpdater update_callback,
-        AccessLocation location,
-        AccessMode mode
-    )
+    CallbackHandler(SystemView& sysview)
         : _sysview { sysview }
-        , _update_callback { update_callback }
-        , _location { location }
-        , _mode { mode }
     { }
-
-    void setSystemDefinition(SPtr<SystemDefinition> sysdef) override { }
-    void update(TimeStep timestep) override
-    {
-        forward_data(_update_callback, _location, _mode, timestep);
-    }
 
     const SystemView& system_view() const { return _sysview; }
 
@@ -67,13 +52,10 @@ public:
 
 private:
     SystemView _sysview;
-    ExternalUpdater _update_callback;
-    AccessLocation _location;
-    AccessMode _mode;
 };
 
 }  // namespace dlext
 }  // namespace md
 }  // namespace hoomd
 
-#endif  // DLEXT_SAMPLER_H_
+#endif  // DLEXT_CALLBACKHANDLER_H_

--- a/dlext/include/DLExt.h
+++ b/dlext/include/DLExt.h
@@ -4,9 +4,8 @@
 #ifndef HOOMD_DLPACK_EXTENSION_H_
 #define HOOMD_DLPACK_EXTENSION_H_
 
-#include "cxx11utils.h"
+#include "SystemView.h"
 #include "dlpack/dlpack.h"
-#include "hoomd/GlobalArray.h"
 
 #include <type_traits>
 #include <vector>
@@ -18,16 +17,20 @@ namespace md
 namespace dlext
 {
 
-using namespace cxx11utils;
-using namespace hoomd;
+namespace cxx11 = cxx11utils;
 
 // { // Aliases
 
-using DLManagedTensorPtr = DLManagedTensor*;
-using DLManagedTensorDeleter = void (*)(DLManagedTensorPtr);
+using DLManagedTensorDeleter = void (*)(DLManagedTensor*);
 
 template <typename T>
 using ArrayHandleUPtr = std::unique_ptr<ArrayHandle<T>>;
+
+template <template <typename> class Array, typename T, typename Object>
+using ArrayPropertyGetter = const Array<T>& (Object::*)() const;
+
+template <typename T>
+using PropertyGetter = T (*)(const SystemView&, AccessLocation, AccessMode);
 
 // } // Aliases
 
@@ -64,22 +67,29 @@ struct DLDataBridge {
 };
 
 template <typename T>
-using DLDataBridgeUPtr = std::unique_ptr<DLDataBridge<T>>;
-
-template <typename T>
-void delete_bridge(DLManagedTensorPtr tensor)
+void delete_bridge(DLManagedTensor* tensor)
 {
     if (tensor)
         delete static_cast<DLDataBridge<T>*>(tensor->manager_ctx);
 }
 
-void do_not_delete(DLManagedTensorPtr tensor) { }
+void do_not_delete(DLManagedTensor* tensor) { }
 
 template <typename T>
 inline void* opaque(T* data) { return static_cast<void*>(data); }
 
 template <typename T>
 inline void* opaque(const T* data) { return (void*)(data); }
+
+inline DLDevice device_info(const SystemView& sysview, AccessLocation location)
+{
+#ifdef ENABLE_CUDA
+    auto gpu_flag = (location == kOnDevice);
+#else
+    auto gpu_flag = false;
+#endif
+    return DLDevice { gpu_flag ? kDLCUDA : kDLCPU, sysview.get_device_id(gpu_flag) };
+}
 
 template <typename>
 constexpr DLDataType dtype();
@@ -106,6 +116,73 @@ template <>
 constexpr int64_t stride1<int3>() { return 3; }
 template <>
 constexpr int64_t stride1<unsigned int>() { return 1; }
+
+template <template <typename> class A, typename T, typename O>
+DLManagedTensor* wrap(
+    const SystemView& sysview, ArrayPropertyGetter<A, T, O> getter,
+    AccessLocation requested_location, AccessMode mode,
+    int64_t size2 = 1, uint64_t offset = 0, uint64_t stride1_offset = 0
+)
+{
+    assert((size2 >= 1));
+
+    auto location = sysview.is_gpu_enabled() ? requested_location : kOnHost;
+    auto handle = cxx11::make_unique<ArrayHandle<T>>(
+        INVOKE(*(sysview.particle_data()), getter)(), location, mode
+    );
+    auto bridge = cxx11::make_unique<DLDataBridge<T>>(handle);
+
+    bridge->tensor.manager_ctx = bridge.get();
+    bridge->tensor.deleter = delete_bridge<T>;
+
+    auto& dltensor = bridge->tensor.dl_tensor;
+    dltensor.data = opaque(bridge->handle->data);
+    dltensor.device = device_info(sysview, location);
+    dltensor.dtype = dtype<T>();
+
+    auto& shape = bridge->shape;
+    shape.push_back(particle_number<A>(sysview));
+    if (size2 > 1)
+        shape.push_back(size2);
+
+    auto& strides = bridge->strides;
+    strides.push_back(stride1<T>() + stride1_offset);
+    if (size2 > 1)
+        strides.push_back(1);
+
+    dltensor.ndim = shape.size();
+    dltensor.shape = reinterpret_cast<std::int64_t*>(shape.data());
+    dltensor.strides = reinterpret_cast<std::int64_t*>(strides.data());
+    dltensor.byte_offset = offset;
+
+    return &(bridge.release()->tensor);
+}
+
+#define DLEXT_PROPERTY_WRAPPER(PROPERTY, GETTER, SIZE1)                                      \
+    struct PROPERTY final {                                                                  \
+        static DLManagedTensor* from(                                                        \
+            const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite \
+        )                                                                                    \
+        {                                                                                    \
+            return wrap(sysview, GETTER, location, mode, SIZE1);                             \
+        }                                                                                    \
+    };
+
+DLEXT_PROPERTY_WRAPPER(PositionsTypes, &ParticleData::getPositions, 4)
+DLEXT_PROPERTY_WRAPPER(VelocitiesMasses, &ParticleData::getVelocities, 4)
+DLEXT_PROPERTY_WRAPPER(Orientations, &ParticleData::getOrientationArray, 4)
+DLEXT_PROPERTY_WRAPPER(AngularMomenta, &ParticleData::getAngularMomentumArray, 4)
+DLEXT_PROPERTY_WRAPPER(MomentsOfInertia, &ParticleData::getMomentsOfInertiaArray, 3)
+DLEXT_PROPERTY_WRAPPER(Charges, &ParticleData::getCharges, 1)
+DLEXT_PROPERTY_WRAPPER(Diameters, &ParticleData::getDiameters, 1)
+DLEXT_PROPERTY_WRAPPER(Images, &ParticleData::getImages, 3)
+DLEXT_PROPERTY_WRAPPER(Tags, &ParticleData::getTags, 1)
+DLEXT_PROPERTY_WRAPPER(RTags, &ParticleData::getRTags, 1)
+DLEXT_PROPERTY_WRAPPER(NetForces, &ParticleData::getNetForce, 4)
+DLEXT_PROPERTY_WRAPPER(NetTorques, &ParticleData::getNetTorqueArray, 4)
+DLEXT_PROPERTY_WRAPPER(NetVirial, &ParticleData::getNetVirial, 6)
+
+#undef DLEXT_PROPERTY_WRAPPER
 
 }  // namespace dlext
 }  // namespace md

--- a/dlext/include/SystemView.h
+++ b/dlext/include/SystemView.h
@@ -4,7 +4,8 @@
 #ifndef HOOMD_SYSVIEW_H_
 #define HOOMD_SYSVIEW_H_
 
-#include "DLExt.h"
+#include "cxx11utils.h"
+#include "hoomd/GlobalArray.h"
 #include "hoomd/System.h"
 
 namespace hoomd
@@ -14,9 +15,8 @@ namespace md
 namespace dlext
 {
 
-namespace cxx11 = cxx11utils;
-
-class DEFAULT_VISIBILITY SystemView;
+using namespace cxx11utils;
+using namespace hoomd;
 
 // { // Aliases
 
@@ -31,13 +31,7 @@ const auto kRead = access_mode::read;
 const auto kReadWrite = access_mode::readwrite;
 const auto kOverwrite = access_mode::overwrite;
 
-template <template <typename> class Array, typename T, typename Object>
-using ArrayPropertyGetter = const Array<T>& (Object::*)() const;
-
-template <typename T>
-using PropertyGetter = T (*)(const SystemView&, AccessLocation, AccessMode);
-
-// } // Aliases
+// { // Aliases
 
 class DEFAULT_VISIBILITY SystemView {
 public:
@@ -61,11 +55,6 @@ private:
     bool _in_context_manager = false;
 };
 
-inline DLDevice dldevice(const SystemView& sysview, bool gpu_flag)
-{
-    return DLDevice { gpu_flag ? kDLCUDA : kDLCPU, sysview.get_device_id(gpu_flag) };
-}
-
 template <template <typename> class>
 unsigned int particle_number(const SystemView& sysview);
 template <>
@@ -78,170 +67,6 @@ inline unsigned int particle_number<GlobalVector>(const SystemView& sysview)
 {
     return sysview.global_particle_number();
 }
-
-template <template <typename> class A, typename T, typename O>
-DLManagedTensorPtr wrap(
-    const SystemView& sysview, ArrayPropertyGetter<A, T, O> getter,
-    AccessLocation requested_location, AccessMode mode,
-    int64_t size2 = 1, uint64_t offset = 0, uint64_t stride1_offset = 0
-)
-{
-    assert((size2 >= 1));
-
-    auto location = sysview.is_gpu_enabled() ? requested_location : kOnHost;
-    auto handle = cxx11::make_unique<ArrayHandle<T>>(
-        INVOKE(*(sysview.particle_data()), getter)(), location, mode
-    );
-    auto bridge = cxx11::make_unique<DLDataBridge<T>>(handle);
-
-#ifdef ENABLE_CUDA
-    auto gpu_flag = (location == kOnDevice);
-#else
-    auto gpu_flag = false;
-#endif
-
-    bridge->tensor.manager_ctx = bridge.get();
-    bridge->tensor.deleter = delete_bridge<T>;
-
-    auto& dltensor = bridge->tensor.dl_tensor;
-    dltensor.data = opaque(bridge->handle->data);
-    dltensor.device = dldevice(sysview, gpu_flag);
-    dltensor.dtype = dtype<T>();
-
-    auto& shape = bridge->shape;
-    shape.push_back(particle_number<A>(sysview));
-    if (size2 > 1)
-        shape.push_back(size2);
-
-    auto& strides = bridge->strides;
-    strides.push_back(stride1<T>() + stride1_offset);
-    if (size2 > 1)
-        strides.push_back(1);
-
-    dltensor.ndim = shape.size();
-    dltensor.shape = reinterpret_cast<std::int64_t*>(shape.data());
-    dltensor.strides = reinterpret_cast<std::int64_t*>(strides.data());
-    dltensor.byte_offset = offset;
-
-    return &(bridge.release()->tensor);
-}
-
-struct PositionsTypes final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getPositions, location, mode, 4);
-    }
-};
-
-struct VelocitiesMasses final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getVelocities, location, mode, 4);
-    }
-};
-
-struct Orientations final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getOrientationArray, location, mode, 4);
-    }
-};
-
-struct AngularMomenta final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getAngularMomentumArray, location, mode, 4);
-    }
-};
-
-struct MomentsOfInertia final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getMomentsOfInertiaArray, location, mode, 3);
-    }
-};
-
-struct Charges final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getCharges, location, mode);
-    }
-};
-
-struct Diameters final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getDiameters, location, mode);
-    }
-};
-
-struct Images final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getImages, location, mode, 3);
-    }
-};
-
-struct Tags final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getTags, location, mode);
-    }
-};
-
-struct RTags final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getRTags, location, mode);
-    }
-};
-
-struct NetForces final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getNetForce, location, mode, 4);
-    }
-};
-
-struct NetTorques final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getNetTorqueArray, location, mode, 4);
-    }
-};
-
-struct NetVirial final {
-    static DLManagedTensorPtr from(
-        const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
-    )
-    {
-        return wrap(sysview, &ParticleData::getNetVirial, location, mode, 6);
-    }
-};
 
 }  // namespace dlext
 }  // namespace md

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(pybind11_MODULE_NAME "dlpack_extension")
+set(pybind11_MODULE_NAME "_api")
 
 pybind11_add_module(${pybind11_MODULE_NAME} MODULE "")
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,6 +2,7 @@ set(pybind11_MODULE_NAME "_api")
 
 pybind11_add_module(${pybind11_MODULE_NAME} MODULE "")
 
+set_version(${pybind11_MODULE_NAME})
 target_sources(${pybind11_MODULE_NAME} PRIVATE hoomd_dlext.cc)
 target_compile_features(${pybind11_MODULE_NAME} PRIVATE cxx_std_11)
 target_link_libraries(${pybind11_MODULE_NAME} PRIVATE ${PROJECT_NAME})

--- a/python/PyDLExt.h
+++ b/python/PyDLExt.h
@@ -4,7 +4,7 @@
 #ifndef PY_HOOMD_DLPACK_EXTENSION_H_
 #define PY_HOOMD_DLPACK_EXTENSION_H_
 
-#include "SystemView.h"
+#include "DLExt.h"
 #ifdef HOOMD2
 #include "hoomd/extern/pybind/include/pybind11/pybind11.h"
 #else
@@ -19,21 +19,21 @@ namespace dlext
 {
 
 using PyCapsule = pybind11::capsule;
-using PyTensorBundle = std::tuple<PyObject*, DLManagedTensorPtr, DLManagedTensorDeleter>;
+using PyTensorBundle = std::tuple<PyObject*, DLManagedTensor*, DLManagedTensorDeleter>;
 
 const char* const kDLTensorCapsuleName = "dltensor";
 const char* const kUsedDLTensorCapsuleName = "used_dltensor";
 
 static std::vector<PyTensorBundle> kPyCapsulesPool;
 
-inline PyCapsule enpycapsulate(DLManagedTensorPtr tensor, bool autodestruct = true)
+inline PyCapsule enpycapsulate(DLManagedTensor* tensor, bool autodestruct = true)
 {
     auto capsule = PyCapsule(tensor, kDLTensorCapsuleName);  // default destructor is nullptr
     if (autodestruct)
         PyCapsule_SetDestructor(
             capsule.ptr(),
             [](PyObject* obj) {  // PyCapsule_Destructor
-                auto dlmt = static_cast<DLManagedTensorPtr>(
+                auto dlmt = static_cast<DLManagedTensor*>(
                     PyCapsule_GetPointer(obj, kDLTensorCapsuleName)
                 );
                 if (dlmt && dlmt->deleter) {
@@ -52,7 +52,7 @@ struct DEFAULT_VISIBILITY PyUnsafeEncapsulator final {
         const SystemView& sysview, AccessLocation location, AccessMode mode = kReadWrite
     )
     {
-        DLManagedTensorPtr tensor = Property::from(sysview, location, mode);
+        DLManagedTensor* tensor = Property::from(sysview, location, mode);
         return enpycapsulate(tensor);
     }
 };

--- a/python/PyHalfStepHook.h
+++ b/python/PyHalfStepHook.h
@@ -10,7 +10,7 @@
 #else
 #include <pybind11/pybind11.h>
 #endif
-#include "Sampler.h"
+#include "CallbackHandler.h"
 
 namespace hoomd
 {

--- a/python/dlext/__init__.py
+++ b/python/dlext/__init__.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: MIT
 # This file is part of `hoomd-dlext`, see LICENSE.md
 
-# flake8:noqa:F401
-
 # API exposed to Python
-from .dlpack_extension import (
+# isort: off
+
+from ._api import (  # noqa: F401 # pylint: disable=E0401
+    # Enums
     AccessLocation,
     AccessMode,
-    DLExtSampler,
+    # Classes
     SystemView,
+    # Methods
     angular_momenta,
     charges,
     diameters,
@@ -21,4 +23,38 @@ from .dlpack_extension import (
     rtags,
     tags,
     velocities_masses,
+    # Other attributes
+    __version__,
 )
+
+# isort: on
+
+kOnHost = AccessLocation.OnHost
+if hasattr(AccessLocation, "OnDevice"):
+    kOnDevice = AccessLocation.OnDevice
+
+kRead = AccessMode.Read
+kReadWrite = AccessMode.ReadWrite
+kOverwrite = AccessMode.Overwrite
+
+
+class DLExtSampler(_api.HalfStepHook):  # noqa: F821
+    """
+    This is a HalfStepHook derived class. It allows the user to set an `update_callback`
+    method which will be passed to `forward_data`, along with a `location` and a `mode`.
+
+    The (non-typed) signature  of `update_callback` is expected to be:
+
+        update_callback(positions_types, velocities_masses, rtags, images, forces, n)
+
+    where `n` is the current time step.
+    """
+
+    def __init__(self, sysview, update_callback, update_location, update_mode):
+        from functools import partial
+
+        super().__init__()
+        callback_handle = _api.CallbackHandler(sysview)  # noqa: F821
+
+        self.forward_data = callback_handle.forward_data
+        self.update = partial(self.forward_data, update_callback, update_location, update_mode)

--- a/python/hoomd_dlext.cc
+++ b/python/hoomd_dlext.cc
@@ -61,6 +61,7 @@ PYBIND11_MODULE(_api, m)
     // instead of `hoomd.dlext._api.x`.
     py::str module_name = m.attr("__name__");
     m.attr("__name__") = "hoomd.dlext";
+    m.attr("__version__") = Py_STRINGIFY(GIT_VERSION);
 
     // Enums
     py::enum_<AccessLocation>(m, "AccessLocation")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100


### PR DESCRIPTION
Currently we define a `Sampler` on the C++ side which has `forward_data` to handle the scope of `hoomd::ArrayHandle`. I have renamed our C++ `Sampler` to `CallbackHandler` and have moved the definition of `Sampler` to the Python side. Hopefully we would sort out issues we were observing when building the conda-forge package.

The PR also adds versioning to the `hoomd.dlext` module, which we were missing.