### PR TITLE
 Stabilize CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
 
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0 # setuptools-scm derives the plugin version from git tags
 
       - name: Set up environment (HOOMD ${{ matrix.hoomd }})
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-name: dlext
           create-args: >-
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,21 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/hoomd-release-check.yml
+++ b/.github/workflows/hoomd-release-check.yml
@@ -1,0 +1,63 @@
+name: Check HOOMD releases
+
+on:
+  schedule:
+    - cron: "0 12 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Check latest conda-forge HOOMD release
+        shell: python
+        run: |
+          import json
+          import re
+          import sys
+          import urllib.request
+          from pathlib import Path
+
+          def version_key(version):
+              match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+              if not match:
+                  raise ValueError(f"Unsupported version format: {version}")
+              return tuple(int(part) for part in match.groups())
+
+          workflow = Path(".github/workflows/ci.yml").read_text()
+          tested_versions = re.findall(r'hoomd:\s*"([0-9]+\.[0-9]+\.[0-9]+)"', workflow)
+          if not tested_versions:
+              sys.exit("No HOOMD versions found in .github/workflows/ci.yml")
+
+          latest_tested = max(tested_versions, key=version_key)
+
+          url = "https://conda.anaconda.org/conda-forge/linux-64/repodata.json"
+          with urllib.request.urlopen(url, timeout=60) as response:
+              repodata = json.load(response)
+
+          available_versions = {
+              package["version"]
+              for section in ("packages", "packages.conda")
+              for package in repodata.get(section, {}).values()
+              if package.get("name") == "hoomd"
+              and re.fullmatch(r"\d+\.\d+\.\d+", package.get("version", ""))
+          }
+          if not available_versions:
+              sys.exit("No HOOMD packages found in conda-forge linux-64 repodata")
+
+          latest_available = max(available_versions, key=version_key)
+
+          print(f"Latest HOOMD in CI matrix: {latest_tested}")
+          print(f"Latest HOOMD on conda-forge: {latest_available}")
+
+          if version_key(latest_available) > version_key(latest_tested):
+              sys.exit(
+                  "A newer HOOMD release is available on conda-forge. "
+                  "Update the latest matrix entry or add a new coverage entry."
+              )


### PR DESCRIPTION
Pin GitHub Actions to commit SHAs and configure monthly Dependabot updates for workflow actions.

Add a scheduled hoomd release check that compares the latest CI matrix entry against conda-forge so new hoomd releases are noticed without making the regression matrix auto-update.